### PR TITLE
Allow convert Value to Deserializer

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -251,7 +251,7 @@ impl<'de> Deserialize<'de> for Value {
     }
 }
 
-struct Deserializer(Value);
+pub struct Deserializer(Value);
 
 impl<'de> serde::Deserializer<'de> for Deserializer {
     type Error = Error;
@@ -672,6 +672,12 @@ impl<'de> serde::Deserializer<'de> for Deserializer {
         V: Visitor<'de>,
     {
         self.deserialize_any(vis)
+    }
+}
+
+impl From<Value> for Deserializer {
+    fn from(v: Value) -> Self {
+        Self(v)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod value;
 pub use value::Value;
 
 mod de;
-pub use de::{from_value, FromValue};
+pub use de::{from_value, Deserializer, FromValue};
 
 mod ser;
 pub use ser::{into_value, IntoValue};


### PR DESCRIPTION
i was considering to use a library [`serde-ignored`](https://github.com/dtolnay/serde-ignored) to print warning logs on unknown fields to inform users about their config file may contains typo. but `serde-ignored` takes a `Deserializer` as input, and `serde-bridge` have not exposed a possible way to convert a `Value` to `Deserializer` yet.

this pr exposes the `Deserializer` as pub, which allows users to pass the `Deserializer` across different serde middlewares like `serde-ignored`.