### PR TITLE
fix: "bound is defined in more than one place" in ci

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -229,10 +229,7 @@ impl serde::Serializer for Serializer {
         Ok(Value::None)
     }
 
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
-    {
+    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Self::Ok, Self::Error> {
         Ok(Value::Some(Box::new(value.serialize(Serializer)?)))
     }
 
@@ -257,30 +254,24 @@ impl serde::Serializer for Serializer {
         })
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T: ?Sized + Serialize>(
         self,
         name: &'static str,
         value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
-    {
+    ) -> Result<Self::Ok, Self::Error> {
         Ok(Value::NewtypeStruct(
             name,
             Box::new(value.serialize(Serializer)?),
         ))
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T: ?Sized + Serialize>(
         self,
         name: &'static str,
         variant_index: u32,
         variant: &'static str,
         value: &T,
-    ) -> Result<Self::Ok, Self::Error>
-    where
-        T: Serialize,
-    {
+    ) -> Result<Self::Ok, Self::Error> {
         Ok(Value::NewtypeVariant {
             name,
             variant_index,
@@ -364,10 +355,7 @@ impl ser::SerializeSeq for SeqSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: Serialize,
-    {
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Self::Error> {
         self.elements.push(value.serialize(Serializer)?);
 
         Ok(())
@@ -394,10 +382,7 @@ impl ser::SerializeTuple for TupleSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: Serialize,
-    {
+    fn serialize_element<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Self::Error> {
         self.elements.push(value.serialize(Serializer)?);
 
         Ok(())
@@ -426,10 +411,7 @@ impl ser::SerializeTupleStruct for TupleStructSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: Serialize,
-    {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Self::Error> {
         self.fields.push(value.serialize(Serializer)?);
 
         Ok(())
@@ -462,10 +444,7 @@ impl ser::SerializeTupleVariant for TupleVariantSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: Serialize,
-    {
+    fn serialize_field<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Self::Error> {
         self.fields.push(value.serialize(Serializer)?);
 
         Ok(())
@@ -499,10 +478,7 @@ impl ser::SerializeMap for MapSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<(), Self::Error>
-    where
-        T: Serialize,
-    {
+    fn serialize_key<T: ?Sized + Serialize>(&mut self, key: &T) -> Result<(), Self::Error> {
         debug_assert!(
             self.cache_key.is_none(),
             "value for the last entry is missing"
@@ -512,10 +488,7 @@ impl ser::SerializeMap for MapSerializer {
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where
-        T: Serialize,
-    {
+    fn serialize_value<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Self::Error> {
         let key = self
             .cache_key
             .take()
@@ -548,14 +521,11 @@ impl ser::SerializeStruct for StructSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(
+    fn serialize_field<T: ?Sized + Serialize>(
         &mut self,
         key: &'static str,
         value: &T,
-    ) -> Result<(), Self::Error>
-    where
-        T: Serialize,
-    {
+    ) -> Result<(), Self::Error> {
         self.fields.insert(key, value.serialize(Serializer)?);
 
         Ok(())
@@ -588,14 +558,11 @@ impl ser::SerializeStructVariant for StructVariantSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(
+    fn serialize_field<T: ?Sized + Serialize>(
         &mut self,
         key: &'static str,
         value: &T,
-    ) -> Result<(), Self::Error>
-    where
-        T: Serialize,
-    {
+    ) -> Result<(), Self::Error> {
         self.fields.insert(key, value.serialize(Serializer)?);
 
         Ok(())


### PR DESCRIPTION
```
error: bound is defined in more than one place
   --> src/ser.rs:447:24
    |
447 |     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
    |                        ^
448 |     where
449 |         T: Serialize,
    |         ^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#multiple_bound_locations
    = note: `-D clippy::multiple-bound-locations` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::multiple_bound_locations)]`

```